### PR TITLE
Fix unused vars in DisciplineSidebar

### DIFF
--- a/src/components/model_LOD_checker_components/DisciplineSidebar.jsx
+++ b/src/components/model_LOD_checker_components/DisciplineSidebar.jsx
@@ -12,7 +12,6 @@ import {
   PanelLeftClose, 
   PanelRightClose 
 } from "lucide-react";
-import { Link, useLocation, useParams } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import {
   Tooltip,
@@ -23,8 +22,6 @@ import {
 import { cn } from "@/lib/utils";
 
 export default function DisciplineSidebar({ selected, onSelect }) {
-  const { accountId, projectId } = useParams();
-  const location = useLocation();
   const [collapsed, setCollapsed] = React.useState(() => {
     const saved = localStorage.getItem("sidebarCollapsed");
     return saved ? JSON.parse(saved) : false;


### PR DESCRIPTION
## Summary
- remove unused router hooks from `DisciplineSidebar`

## Testing
- `npx eslint src/components/model_LOD_checker_components/DisciplineSidebar.jsx`
- `npm run lint` *(fails: no-unused-vars in other files)*

------
https://chatgpt.com/codex/tasks/task_e_68559dba36e48323ad6b4778f33e5299