### PR TITLE
Refactor headers with reusable hooks

### DIFF
--- a/src/components/platform_page_components/acc.platform.header.projects.jsx
+++ b/src/components/platform_page_components/acc.platform.header.projects.jsx
@@ -1,7 +1,9 @@
 import React, { useEffect, useRef, useState } from "react";
-import { useCookies } from "react-cookie";
 import { Link, useNavigate } from "react-router-dom";
 import { FaUser } from "react-icons/fa";
+import useUserProfile from "../../hooks/useUserProfile";
+import useLogout from "../../hooks/useLogout";
+import useProjectData from "../../hooks/useProjectData";
 
 import {
   fetchACCProjectsData,
@@ -10,87 +12,24 @@ import {
 
 import { ProjectsDropdownMenu } from "./drop.down.menu";
 
-const backendUrl =
-  import.meta.env.VITE_API_BACKEND_BASE_URL || "http://localhost:3000";
-
 const ACCPlatformprojectsHeader = ({ accountId, projectId }) => {
-  const [userProfile, setUserProfile] = useState(null);
-  const [error, setError] = useState(null);
+  const { userProfile } = useUserProfile();
+  const handleLogout = useLogout();
+  const { projectsData, project } = useProjectData({
+    accountId,
+    projectId,
+    fetchProjects: fetchACCProjectsData,
+    fetchProject: fetchACCProjectData,
+  });
 
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const navigate = useNavigate();
-  const dropdownRef = useRef(null);
-
   const containerRef = useRef(null);
-  const [newproject, setNewProject] = useState(null);
-
-  //Cookies
-  const [cookies] = useCookies(["access_token"]);
-
-  //Drop Down Menu
-  const [projectDropdownOpen, setProjectDropdownOpen] = useState(false);
-  const [selectedProjectName, setSelectedProjectName] = useState("");
-  const [projectsData, setProjectsData] = useState(null);
-  const [project, setProject] = useState(null);
 
   //console.log("Project ID Header:", projectId);
   //console.log("Account ID Header:", accountId);
 
-  //ProjectsData
-  useEffect(() => {
-    const getProjects = async () => {
-      const projectsData = await fetchACCProjectsData();
 
-      //console.log("Projects Data:", projectData.name);
-
-      setProjectsData(projectsData);
-    };
-    getProjects();
-  }, []);
-
-  //console.log("Projects Data Header:", projectsData?.projects);
-
-  //ProjectData
-  useEffect(() => {
-    const getProject = async () => {
-      const projectData = await fetchACCProjectData(
-        projectId,
-        accountId
-      );
-
-      //console.log("Project Name:", projectData.name);
-
-      setProject(projectData);
-    };
-    getProject();
-  }, [projectId, accountId]);
-
-  //console.log("Project Data Header:", project?.name);
-
-  //User Profile Data
-  useEffect(() => {
-    const getUserProfile = async () => {
-      try {
-        const response = await fetch(`${backendUrl}/general/userprofile`, {
-          credentials: "include",
-        });
-
-        if (!response.ok) {
-          console.error("Error fetching user profile:");
-          setError("Error fetching user profile");
-          return;
-        }
-
-        const data = await response.json();
-        setUserProfile(data.user);
-      } catch (error) {
-        setError(
-          error?.response?.data?.message || "Error fetching user profile"
-        );
-      }
-    };
-    getUserProfile();
-  }, []);
 
   useEffect(() => {
     const handleClickOutside = (e) => {
@@ -105,13 +44,6 @@ const ACCPlatformprojectsHeader = ({ accountId, projectId }) => {
     };
   }, []);
 
-  const handleLogout = async () => {
-    await fetch(`${backendUrl}/auth/logout`, {
-      method: "POST",
-      credentials: "include",
-    });
-    window.location.href = "/";
-  };
 
   const handleGoPlatform = () => {
     navigate("/platform");

--- a/src/components/platform_page_components/bim360.platform.header.projects.jsx
+++ b/src/components/platform_page_components/bim360.platform.header.projects.jsx
@@ -1,7 +1,9 @@
 import React, { useEffect, useRef, useState } from "react";
-import { useCookies } from "react-cookie";
 import { Link, useNavigate } from "react-router-dom";
 import { FaUser } from "react-icons/fa";
+import useUserProfile from "../../hooks/useUserProfile";
+import useLogout from "../../hooks/useLogout";
+import useProjectData from "../../hooks/useProjectData";
 
 import {
   fetchBIM360ProjectsData,
@@ -10,87 +12,24 @@ import {
 
 import { ProjectsDropdownMenu } from "./drop.down.menu";
 
-const backendUrl =
-  import.meta.env.VITE_API_BACKEND_BASE_URL || "http://localhost:3000";
-
 const BIM360PlatformprojectsHeader = ({ accountId, projectId }) => {
-  const [userProfile, setUserProfile] = useState(null);
-  const [error, setError] = useState(null);
+  const { userProfile } = useUserProfile();
+  const handleLogout = useLogout();
+  const { projectsData, project } = useProjectData({
+    accountId,
+    projectId,
+    fetchProjects: fetchBIM360ProjectsData,
+    fetchProject: fetchBIM360ProjectData,
+  });
 
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const navigate = useNavigate();
-  const dropdownRef = useRef(null);
-
   const containerRef = useRef(null);
-  const [newproject, setNewProject] = useState(null);
-
-  //Cookies
-  const [cookies] = useCookies(["access_token"]);
-
-  //Drop Down Menu
-  const [projectDropdownOpen, setProjectDropdownOpen] = useState(false);
-  const [selectedProjectName, setSelectedProjectName] = useState("");
-  const [projectsData, setProjectsData] = useState(null);
-  const [project, setProject] = useState(null);
 
   //console.log("Project ID Header:", projectId);
   //console.log("Account ID Header:", accountId);
 
-  //ProjectsData
-  useEffect(() => {
-    const getProjects = async () => {
-      const projectsData = await fetchBIM360ProjectsData();
 
-      //console.log("Projects Data:", projectData.name);
-
-      setProjectsData(projectsData);
-    };
-    getProjects();
-  }, []);
-
-  //console.log("Projects Data Header:", projectsData?.projects);
-
-  //ProjectData
-  useEffect(() => {
-    const getProject = async () => {
-      const projectData = await fetchBIM360ProjectData(
-        projectId,
-        accountId
-      );
-
-      //console.log("Project Name:", projectData.name);
-
-      setProject(projectData);
-    };
-    getProject();
-  }, [projectId, accountId]);
-
-  //console.log("Project Data Header:", project?.name);
-
-  //User Profile Data
-  useEffect(() => {
-    const getUserProfile = async () => {
-      try {
-        const response = await fetch(`${backendUrl}/general/userprofile`, {
-          credentials: "include",
-        });
-
-        if (!response.ok) {
-          console.error("Error fetching user profile:");
-          setError("Error fetching user profile");
-          return;
-        }
-
-        const data = await response.json();
-        setUserProfile(data.user);
-      } catch (error) {
-        setError(
-          error?.response?.data?.message || "Error fetching user profile"
-        );
-      }
-    };
-    getUserProfile();
-  }, []);
 
   useEffect(() => {
     const handleClickOutside = (e) => {
@@ -105,13 +44,6 @@ const BIM360PlatformprojectsHeader = ({ accountId, projectId }) => {
     };
   }, []);
 
-  const handleLogout = async () => {
-    await fetch(`${backendUrl}/auth/logout`, {
-      method: "POST",
-      credentials: "include",
-    });
-    window.location.href = "/";
-  };
 
   const handleGoPlatform = () => {
     navigate("/platform");

--- a/src/components/platform_page_components/platform.access.header.jsx
+++ b/src/components/platform_page_components/platform.access.header.jsx
@@ -1,44 +1,17 @@
 import React, { useEffect, useRef, useState } from "react";
-import { useCookies } from "react-cookie";
+import useUserProfile from "../../hooks/useUserProfile";
+import useLogout from "../../hooks/useLogout";
 import { Link, useNavigate } from "react-router-dom";
 import { FaUser } from "react-icons/fa";
 
-const backendUrl =
-  import.meta.env.VITE_API_BACKEND_BASE_URL || "http://localhost:3000";
-
 const PlatformHeader = () => {
-  const [userProfile, setUserProfile] = useState(null);
-  const [error, setError] = useState(null);
+  const { userProfile } = useUserProfile();
+  const handleLogout = useLogout();
 
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const navigate = useNavigate();
-  const dropdownRef = useRef(null);
-
   const containerRef = useRef(null);
 
-  useEffect(() => {
-    const getUserProfile = async () => {
-      try {
-        const response = await fetch(`${backendUrl}/general/userprofile`, {
-          credentials: "include",
-        });
-
-        if (!response.ok) {
-          console.error("Error fetching user profile:");
-          setError("Error fetching user profile");
-          return;
-        }
-
-        const data = await response.json();
-        setUserProfile(data.user);
-      } catch (error) {
-        setError(
-          error?.response?.data?.message || "Error fetching user profile"
-        );
-      }
-    };
-    getUserProfile();
-  }, []);
 
   useEffect(() => {
     const handleClickOutside = (e) => {
@@ -53,13 +26,6 @@ const PlatformHeader = () => {
     };
   }, []);
 
-  const handleLogout = async () => {
-    await fetch(`${backendUrl}/auth/logout`, {
-      method: "POST",
-      credentials: "include",
-    });
-    window.location.href = "/";
-  };
 
   const handleGoPlatform = () => {
     navigate("/platform");

--- a/src/hooks/useApiFetch.js
+++ b/src/hooks/useApiFetch.js
@@ -1,0 +1,17 @@
+import { useCallback } from "react";
+
+const backendUrl =
+  import.meta.env.VITE_API_BACKEND_BASE_URL || "http://localhost:3000";
+
+export default function useApiFetch() {
+  return useCallback(async (endpoint, options = {}) => {
+    const url = endpoint.startsWith("http") ? endpoint : `${backendUrl}${endpoint}`;
+    const response = await fetch(url, { credentials: "include", ...options });
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}));
+      const message = errorData.message || response.statusText || "API Error";
+      throw new Error(message);
+    }
+    return response.json();
+  }, []);
+}

--- a/src/hooks/useLogout.js
+++ b/src/hooks/useLogout.js
@@ -1,0 +1,14 @@
+import { useCallback } from "react";
+import useApiFetch from "./useApiFetch";
+
+export default function useLogout() {
+  const apiFetch = useApiFetch();
+  return useCallback(async () => {
+    try {
+      await apiFetch("/auth/logout", { method: "POST" });
+      window.location.href = "/";
+    } catch (err) {
+      console.error("Error logging out:", err);
+    }
+  }, [apiFetch]);
+}

--- a/src/hooks/useProjectData.js
+++ b/src/hooks/useProjectData.js
@@ -1,0 +1,29 @@
+import { useState, useEffect } from "react";
+
+export default function useProjectData({
+  accountId,
+  projectId,
+  fetchProjects,
+  fetchProject,
+}) {
+  const [projectsData, setProjectsData] = useState(null);
+  const [project, setProject] = useState(null);
+
+  useEffect(() => {
+    if (fetchProjects) {
+      fetchProjects()
+        .then(setProjectsData)
+        .catch((err) => console.error("Error fetching projects:", err));
+    }
+  }, [fetchProjects]);
+
+  useEffect(() => {
+    if (fetchProject && projectId && accountId) {
+      fetchProject(projectId, accountId)
+        .then(setProject)
+        .catch((err) => console.error("Error fetching project:", err));
+    }
+  }, [fetchProject, projectId, accountId]);
+
+  return { projectsData, project };
+}

--- a/src/hooks/useUserProfile.js
+++ b/src/hooks/useUserProfile.js
@@ -1,0 +1,19 @@
+import { useState, useEffect } from "react";
+import useApiFetch from "./useApiFetch";
+
+export default function useUserProfile() {
+  const apiFetch = useApiFetch();
+  const [userProfile, setUserProfile] = useState(null);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    apiFetch("/general/userprofile")
+      .then((data) => setUserProfile(data.user))
+      .catch((err) => {
+        console.error("Error fetching user profile:", err);
+        setError(err.message);
+      });
+  }, [apiFetch]);
+
+  return { userProfile, error };
+}


### PR DESCRIPTION
## Summary
- add new reusable hooks: `useApiFetch`, `useUserProfile`, `useProjectData`, `useLogout`
- refactor platform headers to use these hooks

## Testing
- `npm run lint` *(fails: 253 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6855acad47888323a46962778f879ead