### PR TITLE
Implement error boundary

### DIFF
--- a/src/components/general_pages_components/error-boundary.jsx
+++ b/src/components/general_pages_components/error-boundary.jsx
@@ -1,0 +1,31 @@
+import React from "react";
+
+class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error, info) {
+    console.error("ErrorBoundary caught an error", error, info);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="flex flex-col items-center justify-center p-4 text-center">
+          <h1 className="text-xl font-bold">An error has occurred.</h1>
+          <p className="text-gray-600">Please reload the page.</p>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -2,9 +2,12 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import "./index.css";
 import App from "./App.jsx";
+import ErrorBoundary from "./components/general_pages_components/error-boundary.jsx";
 
 createRoot(document.getElementById("root")).render(
   <StrictMode>
-    <App />
+    <ErrorBoundary>
+      <App />
+    </ErrorBoundary>
   </StrictMode>
 );


### PR DESCRIPTION
## Summary
- add a global `ErrorBoundary` component
- wrap application in `ErrorBoundary`
- translate ErrorBoundary messages to English

## Testing
- `npm run lint` *(fails: 274 errors, 14 warnings)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6855ac9113248323b6cf8e99697a2543