### PR TITLE
Add dark mode fixes for project pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,8 +11,14 @@
     />
     <script src="https://developer.api.autodesk.com/modelderivative/v2/viewers/7.*/viewer3D.min.js"></script>
     <title>TAD APP</title>
+    <script>
+      const theme = localStorage.getItem('theme');
+      if (theme === 'dark' || (!theme && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+        document.documentElement.classList.add('dark');
+      }
+    </script>
   </head>
-  <body>
+  <body class="bg-background text-foreground">
     <div id="root"></div>
     <script type="module" src="/src/main.jsx"></script>
   </body>

--- a/src/components/general_pages_components/general.pages.header.jsx
+++ b/src/components/general_pages_components/general.pages.header.jsx
@@ -1,5 +1,6 @@
 import { useState, useRef, useEffect } from "react";
 import { Link, useNavigate } from "react-router-dom";
+import ThemeToggle from "../ui/theme-toggle";
 
 export function Header() {
   const [dropdownOpen, setDropdownOpen] = useState(false);
@@ -20,24 +21,27 @@ export function Header() {
   }, []);
 
   return (
-    <header className="app-header h-[65px] w-full flex justify-between items-center px-6 py-4 fixed top-0 left-0 z-50 shadow-md">
-      <div className="nav-link text - md">
+    <header className="app-header h-[65px] w-full flex justify-between items-center px-6 py-4 fixed top-0 left-0 z-50 shadow-md bg-background dark:bg-gray-900">
+      <div className="nav-link text-md">
         <Link to="/"> TAD | Taller de Arquitectura Digital</Link>
       </div>
-      <nav className="hidden md:flex space-x-6">
-        <Link to="/" className="nav-link">
-          Home
-        </Link>
-        <Link to="/about" className="nav-link">
-          About
-        </Link>
-        <Link to="/services" className="nav-link">
-          Services
-        </Link>
-        <Link to="/login" className="nav-link">
-          Login
-        </Link>
-      </nav>
+      <div className="flex items-center gap-4">
+        <nav className="hidden md:flex space-x-6 items-center">
+          <Link to="/" className="nav-link">
+            Home
+          </Link>
+          <Link to="/about" className="nav-link">
+            About
+          </Link>
+          <Link to="/services" className="nav-link">
+            Services
+          </Link>
+          <Link to="/login" className="nav-link">
+            Login
+          </Link>
+        </nav>
+        <ThemeToggle />
+      </div>
     </header>
   );
 }

--- a/src/components/plans_components/plans.table.jsx
+++ b/src/components/plans_components/plans.table.jsx
@@ -131,8 +131,8 @@ export default function PlansTable({
   };
 
   return (
-    <Card className="w-full bg-white">
-      <CardHeader className="bg-gray-50 pb-2">
+    <Card className="w-full bg-white dark:bg-gray-900">
+      <CardHeader className="bg-gray-50 dark:bg-gray-800 pb-2">
         <div className="flex flex-col md:flex-row justify-between items-center gap-4">
           <CardTitle className="text-xl font-bold">Plans List</CardTitle>
           <div className="flex items-center gap-2 w-full md:w-auto">
@@ -303,10 +303,10 @@ export default function PlansTable({
                 padded.map((plan) =>
                   plan.isPlaceholder ? (
                     <TableRow key={plan.id} className="h-9">
-                      <TableCell colSpan={9} className="bg-gray-50" />
+                      <TableCell colSpan={9} className="bg-gray-50 dark:bg-gray-800" />
                     </TableRow>
                   ) : (
-                    <TableRow key={plan.id} className="hover:bg-gray-50">
+                    <TableRow key={plan.id} className="hover:bg-gray-100 dark:hover:bg-gray-700">
                       {/* 1 */}
                       <TableCell className="p-2">
                         <Checkbox

--- a/src/components/plans_components/table.working.jsx
+++ b/src/components/plans_components/table.working.jsx
@@ -144,9 +144,9 @@ export default function PlansTable({ plans = [] }) { // Props renombradas
 
 
   return (
-    <Card className="w-full bg-white h-full flex flex-col"> {/* Añadido h-full y flex */}
+    <Card className="w-full bg-white dark:bg-gray-900 h-full flex flex-col"> {/* Añadido h-full y flex */}
       {/* Header */}
-      <CardHeader className="bg-slate-50 pb-2 pt-4 px-4 border-b"> {/* Ajustado padding */}
+      <CardHeader className="bg-slate-50 dark:bg-gray-800 pb-2 pt-4 px-4 border-b"> {/* Ajustado padding */}
         <div className="flex flex-col md:flex-row justify-between items-center gap-4"> {/* Añadido items-center */}
           <CardTitle className="text-lg font-semibold">Plans List</CardTitle> {/* Ajustado tamaño */}
           <div className="flex flex-wrap items-center gap-2 w-full md:w-auto"> {/* items-center y flex-wrap */}
@@ -297,7 +297,7 @@ export default function PlansTable({ plans = [] }) { // Props renombradas
       {/* Pagination Footer */}
        {/* Asegurarse que la paginación solo aparezca si hay más de una página y que esté fuera del scroll principal */}
        {totalPages > 1 && (
-         <div className="flex justify-between items-center p-3 border-t bg-white flex-shrink-0"> {/* Estilo consistente */}
+         <div className="flex justify-between items-center p-3 border-t bg-white dark:bg-gray-900 flex-shrink-0"> {/* Estilo consistente */}
            <span className="text-sm text-gray-600">
               Showing {paginated.length} of {sorted.length} plans {/* Texto adaptado */}
            </span>

--- a/src/components/platform_page_components/acc.platform.header.projects.jsx
+++ b/src/components/platform_page_components/acc.platform.header.projects.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useRef, useState } from "react";
 import { useCookies } from "react-cookie";
 import { Link, useNavigate } from "react-router-dom";
 import { FaUser } from "react-icons/fa";
+import ThemeToggle from "../ui/theme-toggle";
 
 import {
   fetchACCProjectsData,
@@ -122,7 +123,7 @@ const ACCPlatformprojectsHeader = ({ accountId, projectId }) => {
   };
 
   return (
-    <header className="app-header h-[65px] w-full flex justify-between items-center px-6 py-4 fixed top-0 left-0 z-50 shadow-md">
+    <header className="app-header h-[65px] w-full flex justify-between items-center px-6 py-4 fixed top-0 left-0 z-50 shadow-md bg-background dark:bg-gray-900">
       {/* Branding (izquierda) */}
       <div className="nav-link flex items-center gap-6 text-md">
         {/* Principal Text */}
@@ -157,17 +158,18 @@ const ACCPlatformprojectsHeader = ({ accountId, projectId }) => {
             Services
           </Link>
         </nav>
+        <ThemeToggle />
 
         {/* Información de usuario y menú desplegable */}
         <div className="relative flex items-center gap-2 text-sm">
           {userProfile ? (
             <>
-              <span>{userProfile.emailId}</span>
+              <span className="dark:text-white">{userProfile.emailId}</span>
               <button
                 className="focus:outline-none"
                 onClick={() => setDropdownOpen(!dropdownOpen)}
               >
-                <FaUser className="h-5 w-5" />
+                <FaUser className="h-5 w-5 dark:text-white" />
               </button>
               {dropdownOpen && (
                 <div className="absolute top-10 right-0 mt-2 bg-black border border-gray-600 rounded-md shadow-lg w-48 z-50 text-white">

--- a/src/components/platform_page_components/bim360.platform.header.projects.jsx
+++ b/src/components/platform_page_components/bim360.platform.header.projects.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useRef, useState } from "react";
 import { useCookies } from "react-cookie";
 import { Link, useNavigate } from "react-router-dom";
 import { FaUser } from "react-icons/fa";
+import ThemeToggle from "../ui/theme-toggle";
 
 import {
   fetchBIM360ProjectsData,
@@ -122,7 +123,7 @@ const BIM360PlatformprojectsHeader = ({ accountId, projectId }) => {
   };
 
   return (
-    <header className="app-header h-[65px] w-full flex justify-between items-center px-6 py-4 fixed top-0 left-0 z-50 shadow-md">
+    <header className="app-header h-[65px] w-full flex justify-between items-center px-6 py-4 fixed top-0 left-0 z-50 shadow-md bg-background dark:bg-gray-900">
       {/* Branding (izquierda) */}
       <div className="nav-link flex items-center gap-6 text-md">
         {/* Principal Text */}
@@ -157,17 +158,18 @@ const BIM360PlatformprojectsHeader = ({ accountId, projectId }) => {
             Services
           </Link>
         </nav>
+        <ThemeToggle />
 
         {/* Información de usuario y menú desplegable */}
         <div className="relative flex items-center gap-2 text-sm">
           {userProfile ? (
             <>
-              <span>{userProfile.emailId}</span>
+              <span className="dark:text-white">{userProfile.emailId}</span>
               <button
                 className="focus:outline-none"
                 onClick={() => setDropdownOpen(!dropdownOpen)}
               >
-                <FaUser className="h-5 w-5" />
+                <FaUser className="h-5 w-5 dark:text-white" />
               </button>
               {dropdownOpen && (
                 <div className="absolute top-10 right-0 mt-2 bg-black border border-gray-600 rounded-md shadow-lg w-48 z-50 text-white">

--- a/src/components/platform_page_components/platform.access.header.jsx
+++ b/src/components/platform_page_components/platform.access.header.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useRef, useState } from "react";
 import { useCookies } from "react-cookie";
 import { Link, useNavigate } from "react-router-dom";
 import { FaUser } from "react-icons/fa";
+import ThemeToggle from "../ui/theme-toggle";
 
 const backendUrl =
   import.meta.env.VITE_API_BACKEND_BASE_URL || "http://localhost:3000";
@@ -70,7 +71,7 @@ const PlatformHeader = () => {
   };
 
   return (
-    <header className="app-header h-[65px] w-full flex justify-between items-center px-6 py-4 fixed top-0 left-0 z-50 shadow-md">
+    <header className="app-header h-[65px] w-full flex justify-between items-center px-6 py-4 fixed top-0 left-0 z-50 shadow-md bg-background dark:bg-gray-900">
       {/* Branding (izquierda) */}
       <div className="nav-link text-md">
         <Link to="/">TAD | Taller de Arquitectura Digital</Link>
@@ -90,17 +91,18 @@ const PlatformHeader = () => {
             Services
           </Link>
         </nav>
+        <ThemeToggle />
 
         {/* Información de usuario y menú desplegable */}
         <div className="relative flex items-center gap-2 text-sm">
           {userProfile ? (
             <>
-              <span>{userProfile.emailId}</span>
+              <span className="dark:text-white">{userProfile.emailId}</span>
               <button
                 className="focus:outline-none"
                 onClick={() => setDropdownOpen(!dropdownOpen)}
               >
-                <FaUser className="h-5 w-5" />
+                <FaUser className="h-5 w-5 dark:text-white" />
               </button>
               {dropdownOpen && (
                 <div className="absolute top-10 right-0 mt-2 bg-[#f6f6f6] border border-gray-600 rounded-md shadow-lg w-48 z-50 text-black">

--- a/src/components/ui/theme-toggle.jsx
+++ b/src/components/ui/theme-toggle.jsx
@@ -1,0 +1,43 @@
+import { useEffect, useState } from "react";
+import { FaSun, FaMoon } from "react-icons/fa";
+import { Button } from "./button";
+
+export default function ThemeToggle() {
+  const [isDark, setIsDark] = useState(false);
+
+  useEffect(() => {
+    const stored = localStorage.getItem("theme");
+    const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+    const dark = stored === "dark" || (!stored && prefersDark);
+    if (dark) {
+      document.documentElement.classList.add("dark");
+    } else {
+      document.documentElement.classList.remove("dark");
+    }
+    setIsDark(dark);
+  }, []);
+
+  const toggle = () => {
+    const next = !isDark;
+    setIsDark(next);
+    if (next) {
+      document.documentElement.classList.add("dark");
+      localStorage.setItem("theme", "dark");
+    } else {
+      document.documentElement.classList.remove("dark");
+      localStorage.setItem("theme", "light");
+    }
+  };
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      className="focus:outline-none"
+      onClick={toggle}
+      aria-label="Toggle Theme"
+    >
+      {isDark ? <FaSun /> : <FaMoon />}
+    </Button>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -172,7 +172,7 @@
 @layer components {
   /* Header y Sidebar homogéneos */
   .app-header{
-    @apply bg-[#ffffff] text-black;
+    @apply bg-background text-foreground;
   }
 
   .app-sidebar {
@@ -196,7 +196,7 @@
   }
 
   .nav-link {
-    @apply text-black transition-colors;
+    @apply text-black dark:text-gray-200 transition-colors;
   }
 
   .nav-link:hover {

--- a/src/pages/About.Page.jsx
+++ b/src/pages/About.Page.jsx
@@ -55,7 +55,7 @@ const AboutPage = () => {
   };
 
   return (
-    <div className="relative flex flex-col min-h-screen bg-white z-10">
+    <div className="relative flex flex-col min-h-screen bg-background dark:bg-gray-900 text-foreground z-10">
       <Particles
         id="tsparticles"
         init={particlesInit}
@@ -65,12 +65,11 @@ const AboutPage = () => {
 
       <Header className="relative z-10" />
 
-      <main className="relative z-10 flex flex-1 flex-row items-center justify-center px-8 py-8 mt-20">
+      <main className="relative z-10 flex flex-1 flex-col md:flex-row items-center justify-center px-4 md:px-8 py-8 mt-20 gap-6">
         <div className="w-1/2 flex items-center justify-center h-[60vh]">
           <h1 className="text-7xl font-semibold text-primary">T A D</h1>
         </div>
-
-        <div className="w-1/2 flex flex-col justify-center items-center text-center">
+        <div className="w-full md:w-1/2 flex flex-col justify-center items-center text-center">
           <h1 className="text-4xl md:text-5xl lg:text-6xl font-bold mb-4">
             About Us
           </h1>

--- a/src/pages/Home.Page.jsx
+++ b/src/pages/Home.Page.jsx
@@ -57,7 +57,7 @@ const HomePage = () => {
   };
 
   return (
-    <div className="relative flex flex-col min-h-screen bg-white">
+    <div className="relative flex flex-col min-h-screen bg-background dark:bg-gray-900 text-foreground">
       <Particles
         id="tsparticles"
         init={particlesInit}
@@ -67,12 +67,11 @@ const HomePage = () => {
 
       <Header className="relative z-10" />
 
-      <main className="relative z-10 flex flex-1 flex-row items-center justify-center px-8 py-8 mt-20">
-        <div className="w-1/2 flex items-center justify-center h-[60vh]">
+      <main className="relative z-10 flex flex-1 flex-col md:flex-row items-center justify-center px-4 md:px-8 py-8 mt-20 gap-6">
+        <div className="w-full md:w-1/2 flex items-center justify-center h-[60vh]">
           <h1 className="text-7xl font-semibold text-primary">T A D</h1>
         </div>
-
-        <div className="w-1/2 flex flex-col justify-center items-center text-center px-6">
+        <div className="w-full md:w-1/2 flex flex-col justify-center items-center text-center px-6">
           <h1 className="text-4xl md:text-5xl lg:text-6xl font-bold mb-4">
             Improve Your <span className="text-primary">BIM</span> &{" "}
             <span className="text-primary">VDC</span> Integration

--- a/src/pages/Login.Page.jsx
+++ b/src/pages/Login.Page.jsx
@@ -110,7 +110,7 @@ const LoginPage = () => {
   };
 
   return (
-    <div className="relative flex flex-col min-h-screen bg-white z-10">
+    <div className="relative flex flex-col min-h-screen bg-background dark:bg-gray-900 text-foreground z-10">
       {/* Background Particles (non-blocking interaction) */}
       <Particles
         id="tsparticles"
@@ -123,14 +123,14 @@ const LoginPage = () => {
       <Header className="relative z-10" />
 
       {/* Main Content */}
-      <main className="relative z-10 flex flex-1 flex-row items-center justify-center px-8 py-8 mt-20">
+      <main className="relative z-10 flex flex-1 flex-col md:flex-row items-center justify-center px-4 md:px-8 py-8 mt-20 gap-6">
         {/* Left Side */}
-        <div className="w-1/2 flex items-center justify-center h-[60vh]">
+        <div className="w-full md:w-1/2 flex items-center justify-center h-[60vh]">
           <h1 className="text-7xl font-semibold text-primary">T A D</h1>
         </div>
 
         {/* Right Side */}
-        <div className="w-1/2 flex flex-col justify-center items-center text-center">
+        <div className="w-full md:w-1/2 flex flex-col justify-center items-center text-center">
           <h1 className="text-4xl md:text-5xl lg:text-6xl font-bold mb-6">
             TAD APP | Login
           </h1>

--- a/src/pages/NotAllowed.jsx
+++ b/src/pages/NotAllowed.jsx
@@ -59,7 +59,7 @@ const NotAuthorizedPage = () => {
 
   // Render: Particle background + Unauthorized Message layout
   return (
-    <div className="relative flex flex-col min-h-screen bg-white">
+    <div className="relative flex flex-col min-h-screen bg-background dark:bg-gray-900 text-foreground">
       {/* Background Particles (non-blocking interaction) */}
       <Particles
         id="tsparticles"
@@ -72,14 +72,14 @@ const NotAuthorizedPage = () => {
       <Header className="relative z-10" />
 
       {/* Main Content */}
-      <main className="relative z-10 flex flex-1 flex-row items-center justify-center px-8 py-8 mt-20">
+      <main className="relative z-10 flex flex-1 flex-col md:flex-row items-center justify-center px-4 md:px-8 py-8 mt-20 gap-6">
         {/* Left Side */}
-        <div className="w-1/2 flex items-center justify-center h-[60vh]">
+        <div className="w-full md:w-1/2 flex items-center justify-center h-[60vh]">
           <h1 className="text-7xl font-semibold text-primary">T A D</h1>
         </div>
 
         {/* Right Side */}
-        <div className="w-1/2 flex flex-col justify-center items-center text-center px-6">
+        <div className="w-full md:w-1/2 flex flex-col justify-center items-center text-center px-6">
           <h1 className="text-4xl md:text-5xl lg:text-6xl font-bold mb-4">
             Not Authorized<br />
             Please Contact the Administrator

--- a/src/pages/NotFound.Page.jsx
+++ b/src/pages/NotFound.Page.jsx
@@ -59,7 +59,7 @@ const NotFoundPage = () => {
 
   // Render: Page structure for 404 Not Found
   return (
-    <div className="relative flex flex-col min-h-screen bg-white">
+    <div className="relative flex flex-col min-h-screen bg-background dark:bg-gray-900 text-foreground">
       {/* Background Particles (non-blocking interaction) */}
       <Particles
         id="tsparticles"
@@ -72,14 +72,14 @@ const NotFoundPage = () => {
       <Header className="relative z-10" />
 
       {/* Main Content */}
-      <main className="relative z-10 flex flex-1 flex-row items-center justify-center px-8 py-8 mt-20">
+      <main className="relative z-10 flex flex-1 flex-col md:flex-row items-center justify-center px-4 md:px-8 py-8 mt-20 gap-6">
         {/* Left Side */}
-        <div className="w-1/2 flex items-center justify-center h-[60vh]">
+        <div className="w-full md:w-1/2 flex items-center justify-center h-[60vh]">
           <h1 className="text-7xl font-semibold text-primary">T A D</h1>
         </div>
 
         {/* Right Side */}
-        <div className="w-1/2 flex flex-col justify-center items-center text-center px-6">
+        <div className="w-full md:w-1/2 flex flex-col justify-center items-center text-center px-6">
           <h1 className="text-4xl md:text-5xl lg:text-6xl font-bold mb-4">
             Not Found
           </h1>

--- a/src/pages/Platform.Page.jsx
+++ b/src/pages/Platform.Page.jsx
@@ -68,7 +68,7 @@ const PlatformPage = () => {
 
   // Render: Page layout with platform selector and particle background
   return (
-    <div className="relative flex flex-col min-h-screen bg-white z-10">
+    <div className="relative flex flex-col min-h-screen bg-background dark:bg-gray-900 text-foreground z-10">
       {/* Background Particles (non-blocking interaction) */}
       <Particles
         id="tsparticles"
@@ -81,14 +81,14 @@ const PlatformPage = () => {
       <PlatformHeader className="relative z-10" />
 
       {/* Main Content */}
-      <main className="relative z-10 flex flex-1 flex-row items-center justify-center px-8 py-8 mt-20">
+      <main className="relative z-10 flex flex-1 flex-col md:flex-row items-center justify-center px-4 md:px-8 py-8 mt-20 gap-6">
         {/* Left Side */}
-        <div className="w-1/2 flex items-center justify-center h-[60vh]">
+        <div className="w-full md:w-1/2 flex items-center justify-center h-[60vh]">
           <h1 className="text-7xl font-semibold text-primary">T A D</h1>
         </div>
 
         {/* Right Side */}
-        <div className="w-1/2 flex flex-col justify-center items-center text-center">
+        <div className="w-full md:w-1/2 flex flex-col justify-center items-center text-center">
           <h1 className="text-4xl md:text-5xl lg:text-6xl font-bold mb-6">
             TAD APP | Select Your Platform
           </h1>

--- a/src/pages/Services.Page.jsx
+++ b/src/pages/Services.Page.jsx
@@ -55,7 +55,7 @@ const ServicesPage = () => {
   };
 
   return (
-    <div className="relative flex flex-col min-h-screen bg-white z-10">
+    <div className="relative flex flex-col min-h-screen bg-background dark:bg-gray-900 text-foreground z-10">
       {/* Background Particles (non-blocking interaction) */}
       <Particles
         id="tsparticles"
@@ -68,14 +68,14 @@ const ServicesPage = () => {
       <Header className="relative z-10" />
 
       {/* Main Content */}
-      <main className="relative z-10 flex flex-1 flex-row items-center justify-center px-8 py-8 mt-20">
+      <main className="relative z-10 flex flex-1 flex-col md:flex-row items-center justify-center px-4 md:px-8 py-8 mt-20 gap-6">
         {/* Left Side */}
-        <div className="w-1/2 flex items-center justify-center h-[60vh]">
+        <div className="w-full md:w-1/2 flex items-center justify-center h-[60vh]">
           <h1 className="text-7xl font-semibold text-primary">T A D</h1>
         </div>
 
         {/* Right Side */}
-        <div className="w-1/2 flex flex-col justify-center items-center text-center">
+        <div className="w-full md:w-1/2 flex flex-col justify-center items-center text-center">
           <h1 className="text-4xl md:text-5xl lg:text-6xl font-bold mb-4">
             Services
           </h1>

--- a/src/pages/acc/acc.projects.page.jsx
+++ b/src/pages/acc/acc.projects.page.jsx
@@ -83,7 +83,7 @@ const ACCProjectsPage = () => {
   };
 
   return (
-    <div className="relative flex flex-col min-h-screen bg-[#ffffff] z-10">
+    <div className="relative flex flex-col min-h-screen bg-background dark:bg-gray-900 z-10">
       {loading && <LoadingOverlay />}
       {/* Decorative background particle animation */}
       <Particles
@@ -121,7 +121,7 @@ const ACCProjectsPage = () => {
                 {projects.map((project) => (
                   <li
                     key={project.id}
-                    className="bg-gray-100 shadow-md rounded-lg p-4 flex justify-between items-center"
+                    className="bg-gray-100 dark:bg-gray-700 shadow-md rounded-lg p-4 flex justify-between items-center"
                   >
                     <div>
                       <h2 className="text-m font-semibold">

--- a/src/pages/bim360/bim360.projects.page.jsx
+++ b/src/pages/bim360/bim360.projects.page.jsx
@@ -79,7 +79,7 @@ const BIM360ProjectsPage = () => {
   };
 
   return (
-    <div className="relative flex flex-col min-h-screen bg-[#ffffff] z-10">
+    <div className="relative flex flex-col min-h-screen bg-background dark:bg-gray-900 z-10">
           {loading && <LoadingOverlay />}
           {/* Partículas cubriendo todo, sin bloquear interacciones */}
           <Particles
@@ -115,7 +115,7 @@ const BIM360ProjectsPage = () => {
                 {projects.map((project) => (
                   <li
                     key={project.id}
-                    className="bg-gray-100 shadow-md rounded-lg p-4 flex justify-between items-center"
+                    className="bg-gray-100 dark:bg-gray-700 shadow-md rounded-lg p-4 flex justify-between items-center"
                   >
                     <div>
                       <h2 className="text-m font-semibold">


### PR DESCRIPTION
## Summary
- adjust header text colors in platform headers for dark mode
- use CSS variables for header background
- enable dark backgrounds on project listing pages

## Testing
- `npm run lint` *(fails: 274 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6855b10d73488323963bb756f20e18dd