### PR TITLE
Add VR viewer page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,6 @@
-<<<<<<< HEAD
-# React + Vite
-
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
-
-Currently, two official plugins are available:
-
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react/README.md) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
-
-## Expanding the ESLint configuration
-
-If you are developing a production application, we recommend using TypeScript and enable type-aware lint rules. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
-=======
 # TAD-APP-Fronend
-TAD-APP-Fronend
->>>>>>> 0d465505cda816f13c117229ca450ea61acfb01b
+
+This project is a React + Vite application for the TAD platform.
 
 ## Proposed Viewer Extensions
 
@@ -25,3 +11,27 @@ The Autodesk Platform Services viewer supports many optional extensions. Conside
 - `Autodesk.Viewing.MarkupsCore` for markup and annotation features.
 
 These extensions can enhance the user experience when working with the built-in APS viewer.
+
+## VR Viewer
+
+The VR viewer allows inspection of the federated model using a WebXR compatible headset such as the Oculus (Meta Quest).
+
+### Installation
+
+```bash
+npm install three
+```
+
+If you plan to load GLTF/GLB models you may also need the `GLTFLoader` from the `three` examples:
+
+```bash
+npm install three/examples/jsm/loaders/GLTFLoader.js
+```
+
+### Using Oculus
+
+1. Open the application in the **Oculus Browser**.
+2. Navigate to the VR page and wait for the model to load.
+3. Press the **VR** button to start the immersive experience.
+
+If your model is not in GLTF/GLB format you will need to convert it before using the VR viewer.

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "react-slick": "^0.30.3",
     "react-tsparticles": "^2.12.2",
     "slick-carousel": "^1.8.1",
+    "three": "^0.165.0",
     "tailwind-merge": "^3.2.0",
     "tailwindcss-animate": "^1.0.7",
     "tsparticles-slim": "^2.12.0",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -22,6 +22,7 @@ import ACC6DDatabase from "./pages/acc/acc.database.6D";
 import ACCProjectPlansPage from "./pages/acc/acc.project.plans.jsx";
 import ACCProjectTaskManagementPage from "./pages/acc/acc.task.management.page.jsx";
 import ACCModelLODCheckerPage from "./pages/acc/acc.model.lod.checker.page.jsx";
+import ACCVRPage from "./pages/acc/acc.vr.jsx";
 
 //BIM360 Pages
 import BIM360ProjectsPage from "./pages/bim360/bim360.projects.page.jsx";
@@ -99,6 +100,10 @@ function App() {
             <Route
               path="/accprojects/:accountId/:projectId/lod-checker"
               element={<ACCModelLODCheckerPage />}
+            />
+            <Route
+              path="/accprojects/:accountId/:projectId/vr"
+              element={<ACCVRPage />}
             />
 
             {/* BIM360 Pages */}

--- a/src/components/aec_model_components/vr.viewer.jsx
+++ b/src/components/aec_model_components/vr.viewer.jsx
@@ -1,0 +1,78 @@
+import React, { useEffect, useRef } from "react";
+import * as THREE from "three";
+import { GLTFLoader } from "three/examples/jsm/loaders/GLTFLoader";
+import { VRButton } from "three/examples/jsm/webxr/VRButton";
+
+const VRViewer = ({ modelUrl }) => {
+  const mountRef = useRef(null);
+
+  useEffect(() => {
+    const container = mountRef.current;
+    if (!container || !modelUrl) return;
+
+    const isGLTF = modelUrl.endsWith(".gltf") || modelUrl.endsWith(".glb");
+    if (!isGLTF) {
+      container.innerHTML =
+        "<p class='text-center text-red-500'>VR viewer supports GLTF/GLB models only. Please convert your model.</p>";
+      return;
+    }
+
+    const scene = new THREE.Scene();
+    const camera = new THREE.PerspectiveCamera(
+      75,
+      container.clientWidth / container.clientHeight,
+      0.1,
+      1000
+    );
+    camera.position.set(0, 1.6, 3);
+
+    const renderer = new THREE.WebGLRenderer({ antialias: true });
+    renderer.setSize(container.clientWidth, container.clientHeight);
+    renderer.xr.enabled = true;
+    container.appendChild(renderer.domElement);
+    container.appendChild(VRButton.createButton(renderer));
+
+    const light = new THREE.HemisphereLight(0xffffff, 0x444444);
+    light.position.set(0, 200, 0);
+    scene.add(light);
+
+    const loader = new GLTFLoader();
+    loader.load(
+      modelUrl,
+      (gltf) => {
+        scene.add(gltf.scene);
+      },
+      undefined,
+      (error) => {
+        console.error("Error loading model", error);
+      }
+    );
+
+    const animate = () => {
+      renderer.setAnimationLoop(() => {
+        renderer.render(scene, camera);
+      });
+    };
+    animate();
+
+    const handleResize = () => {
+      camera.aspect = container.clientWidth / container.clientHeight;
+      camera.updateProjectionMatrix();
+      renderer.setSize(container.clientWidth, container.clientHeight);
+    };
+    window.addEventListener("resize", handleResize);
+
+    return () => {
+      window.removeEventListener("resize", handleResize);
+      renderer.setAnimationLoop(null);
+      renderer.dispose();
+      while (container.firstChild) {
+        container.removeChild(container.firstChild);
+      }
+    };
+  }, [modelUrl]);
+
+  return <div ref={mountRef} className="w-full h-[600px] bg-black" />;
+};
+
+export default VRViewer;

--- a/src/pages/acc/acc.vr.jsx
+++ b/src/pages/acc/acc.vr.jsx
@@ -1,0 +1,39 @@
+import React, { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+
+import ACCPlatformLayout from "../../components/platform_page_components/acc.platform.layout";
+import LoadingOverlay from "../../components/general_pages_components/general.loading.overlay";
+import VRViewer from "../../components/aec_model_components/vr.viewer";
+
+import { fetchACCFederatedModel } from "../services/acc.services";
+
+const ACCVRPage = () => {
+  const { projectId, accountId } = useParams();
+  const [modelUrl, setModelUrl] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    setLoading(true);
+    setError(null);
+    fetchACCFederatedModel(projectId, accountId)
+      .then((url) => setModelUrl(url))
+      .catch((err) => {
+        console.error(err);
+        setError(err);
+      })
+      .finally(() => setLoading(false));
+  }, [projectId, accountId]);
+
+  return (
+    <ACCPlatformLayout projectId={projectId} accountId={accountId}>
+      {loading && <LoadingOverlay />}
+      {error && (
+        <p className="text-red-500 p-4">Failed to load federated model.</p>
+      )}
+      {modelUrl && <VRViewer modelUrl={modelUrl} />}
+    </ACCPlatformLayout>
+  );
+};
+
+export default ACCVRPage;


### PR DESCRIPTION
## Summary
- add `three` dependency
- document VR viewing with Oculus Browser
- implement WebXR viewer component with Three.js
- add ACC VR page and route

## Testing
- `npm run lint` *(fails: 214 errors)*

------
https://chatgpt.com/codex/tasks/task_e_685617c4ada883238ed75db6da40b014