### PR TITLE
Add VR viewer page using Three.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,14 @@ The Autodesk Platform Services viewer supports many optional extensions. Conside
 - `Autodesk.Viewing.MarkupsCore` for markup and annotation features.
 
 These extensions can enhance the user experience when working with the built-in APS viewer.
+
+## VR Viewer Usage
+
+To enable the WebXR viewer you need Three.js and its GLTF loader:
+
+```bash
+npm install three
+npm install three/examples/jsm/loaders/GLTFLoader.js
+```
+
+Open the application in the Oculus Browser and navigate to the VR viewer page. Press the **VR** button to start the immersive experience. The viewer only supports models in **GLTF** or **GLB** format. If your federated model is in another format you must convert it before using this feature.

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "react-slick": "^0.30.3",
     "react-tsparticles": "^2.12.2",
     "slick-carousel": "^1.8.1",
+    "three": "^0.165.0",
     "tailwind-merge": "^3.2.0",
     "tailwindcss-animate": "^1.0.7",
     "tsparticles-slim": "^2.12.0",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -22,6 +22,7 @@ import ACC6DDatabase from "./pages/acc/acc.database.6D";
 import ACCProjectPlansPage from "./pages/acc/acc.project.plans.jsx";
 import ACCProjectTaskManagementPage from "./pages/acc/acc.task.management.page.jsx";
 import ACCModelLODCheckerPage from "./pages/acc/acc.model.lod.checker.page.jsx";
+import ACCVRPage from "./pages/acc/acc.vr.jsx";
 
 //BIM360 Pages
 import BIM360ProjectsPage from "./pages/bim360/bim360.projects.page.jsx";
@@ -99,6 +100,10 @@ function App() {
             <Route
               path="/accprojects/:accountId/:projectId/lod-checker"
               element={<ACCModelLODCheckerPage />}
+            />
+            <Route
+              path="/accprojects/:accountId/:projectId/vr-viewer"
+              element={<ACCVRPage />}
             />
 
             {/* BIM360 Pages */}

--- a/src/components/aec_model_components/vr.viewer.jsx
+++ b/src/components/aec_model_components/vr.viewer.jsx
@@ -1,0 +1,72 @@
+import React, { useRef, useEffect } from "react";
+import * as THREE from "three";
+import { VRButton } from "three/examples/jsm/webxr/VRButton.js";
+import { GLTFLoader } from "three/examples/jsm/loaders/GLTFLoader.js";
+
+const VRViewer = ({ model }) => {
+  const containerRef = useRef(null);
+  const rendererRef = useRef(null);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container || !model) return;
+
+    const isGLTF = ["gltf", "glb"].includes(model.split(".").pop().toLowerCase());
+    if (!isGLTF) return () => {};
+
+    const scene = new THREE.Scene();
+    const camera = new THREE.PerspectiveCamera(
+      70,
+      container.clientWidth / container.clientHeight,
+      0.1,
+      1000
+    );
+    const renderer = new THREE.WebGLRenderer({ antialias: true });
+    renderer.setSize(container.clientWidth, container.clientHeight);
+    renderer.xr.enabled = true;
+    container.appendChild(renderer.domElement);
+    container.appendChild(VRButton.createButton(renderer));
+
+    const light = new THREE.HemisphereLight(0xffffff, 0x444444);
+    scene.add(light);
+
+    const loader = new GLTFLoader();
+    loader.load(
+      model,
+      (gltf) => {
+        scene.add(gltf.scene);
+        renderer.setAnimationLoop(() => {
+          renderer.render(scene, camera);
+        });
+      },
+      undefined,
+      (err) => console.error("Error loading model", err)
+    );
+
+    camera.position.set(0, 1.6, 3);
+
+    rendererRef.current = renderer;
+
+    return () => {
+      renderer.setAnimationLoop(null);
+      renderer.dispose();
+      while (container.firstChild) container.removeChild(container.firstChild);
+    };
+  }, [model]);
+
+  const isGLTF = model
+    ? ["gltf", "glb"].includes(model.split(".").pop().toLowerCase())
+    : false;
+
+  return (
+    <div className="w-full h-full" ref={containerRef}>
+      {model && !isGLTF && (
+        <p className="text-red-500">
+          Modelo no soportado. Conviértalo a GLTF/GLB para usar el visor VR.
+        </p>
+      )}
+    </div>
+  );
+};
+
+export default VRViewer;

--- a/src/pages/acc/acc.vr.jsx
+++ b/src/pages/acc/acc.vr.jsx
@@ -1,0 +1,47 @@
+import React, { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+
+import ACCPlatformLayout from "../../components/platform_page_components/acc.platform.layout";
+import LoadingOverlay from "../../components/general_pages_components/general.loading.overlay";
+import VRViewer from "../../components/aec_model_components/vr.viewer";
+
+import { fetchACCFederatedModel } from "../../pages/services/acc.services";
+
+const ACCVRPage = () => {
+  const { projectId, accountId } = useParams();
+  const [federatedModel, setFederatedModel] = useState(null);
+  const [error, setError] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    setLoading(true);
+    setError(null);
+    Promise.all([fetchACCFederatedModel(projectId, accountId)])
+      .then(([federatedModelResp]) => {
+        setFederatedModel(federatedModelResp);
+      })
+      .catch((err) => {
+        console.error(err);
+        setError(err);
+      })
+      .finally(() => setLoading(false));
+  }, [projectId, accountId]);
+
+  return (
+    <ACCPlatformLayout projectId={projectId} accountId={accountId}>
+      {loading && <LoadingOverlay />}
+      <div className="flex flex-col w-full h-full">
+        <h1 className="text-right text-xl text-black mt-2">VR VIEWER</h1>
+        <hr className="my-4 border-t border-gray-300" />
+        {error && (
+          <p className="text-red-500">Error loading model: {error.message}</p>
+        )}
+        <div className="flex-1 h-[600px]">
+          <VRViewer model={federatedModel} />
+        </div>
+      </div>
+    </ACCPlatformLayout>
+  );
+};
+
+export default ACCVRPage;


### PR DESCRIPTION
## Summary
- implement WebXR viewer component with Three.js
- add VR viewer page under ACC routes
- register the route in the app router
- document VR usage and dependencies
- add three.js dependency

## Testing
- `npm run lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_685630b9fdc8832393ea63c6b2abf609